### PR TITLE
Fix error message

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -8,7 +8,8 @@ module.exports = function() {
     Error.call(this);
     Error.captureStackTrace(this, this.constructor);
     this.name = this.constructor.name;
-    this.message = { status: status, message: statusCodes[status] };
+    this.status = status;
+    this.message = statusCodes[status];
   } HTTPError.prototype.__proto__ = Error.prototype;
 
 

--- a/test/errors.js
+++ b/test/errors.js
@@ -11,7 +11,7 @@ describe('Simple OAuth2 Error',function() {
 
 		beforeEach(function(done) {
 			var params = { 'code': 'code', 'redirect_uri': 'http://callback.com', 'grant_type': 'authorization_code', 'client_id': 'client-id', 'client_secret': 'client-secret' };
-			request = nock('https://example.org:443').post('/oauth/token', qs.stringify(params)).reply(401, 'Unauthorized');
+			request = nock('https://example.org:443').post('/oauth/token', qs.stringify(params)).reply(401);
 			done();
 		});
 
@@ -27,7 +27,8 @@ describe('Simple OAuth2 Error',function() {
 		});
 
 		it('returns an access token',function() {
-			error.message.message.should.eql('Unauthorized');
+			error.message.should.eql('Unauthorized');
+			error.status.should.eql(401);
 		});
 	});
 
@@ -35,7 +36,7 @@ describe('Simple OAuth2 Error',function() {
 
 		beforeEach(function(done) {
 			var params = { 'code': 'code', 'redirect_uri': 'http://callback.com', 'grant_type': 'authorization_code', 'client_id': 'client-id', 'client_secret': 'client-secret' };
-			request = nock('https://example.org:443').post('/oauth/token', qs.stringify(params)).reply(500, 'Server Error');
+			request = nock('https://example.org:443').post('/oauth/token', qs.stringify(params)).reply(500);
 			done();
 		});
 
@@ -51,7 +52,8 @@ describe('Simple OAuth2 Error',function() {
 		});
 
 		it('returns an access token',function() {
-			error.message.message.should.eql('Internal Server Error');
+			error.message.should.eql('Internal Server Error');
+			error.status.should.eql(500);
 		});
 	});
 })


### PR DESCRIPTION
When an error is thrown as follows:

``` javascript
throw new HTTPError(403);
```

If `error.message` is Object, an error message is displayed as follows.

```
HTTPError: [object Object]
    at ...
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:906:3
```

`[object Object]` is not good.

This patch fixed it. An error message will be displayed as follows.

```
HTTPError: Forbidden
    at ...
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:906:3
```
