### PR TITLE
Not using headers if access_token is defined as a part of the URL.

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -11,6 +11,10 @@ module.exports = function(config) {
 
   // High level method to call API
   function api(method, path, params, callback) {
+    if (typeof params === 'function') {
+      callback = params;
+      params = {};
+    }
 
     if(!callback || typeof(callback) !== 'function') {
       throw new Error('Callback not provided on API call');


### PR DESCRIPTION
Hi again! 

I might be way off here, but if we pass on the access_token as a part of the query string, one shouldn't set the headers?

For instance, if I want to send a POST request I would have to do:

``` javascript
oauth.api('POST', '/api?access_token=' + someAccessToken, {
  'some': 'object'
});
```

As if I pass it as params I will have the access_token as a part of my post payload, and if restful that should be just the object I'm trying to create?

Any thoughts?
