### PR TITLE
Make it optional to duplicate authorization params in the body.

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -62,7 +62,7 @@ module.exports = function(config) {
     if (method == 'GET') options.qs   = params;
 
     // Enable the system to send authorization params in the body (for example github does not require to be in the header)
-    if (method != 'GET' && options.form && !params.password) {
+    if (!config.disableBodyAuth && method != 'GET' && options.form && !params.password) {
       options.form.client_id = config.clientID;
       options.form[config.clientSecretParameterName] = config.clientSecret;
     }


### PR DESCRIPTION
Make it optional to duplicate authorization params in the body. I ran into a case where an OAuth2 server rejected requests but these params were unexpected.