### PR TITLE
Allow mobile app authorization URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Simple OAuth2 accepts an object with the following valid params.
 * `useBasicAuthorizationHeader` - Whether or not the `Authorization: Basic ...` header is set on the request.
 Defaults to `true`.
 * `clientSecretParameterName` - Parameter name for the client secret. Defaults to `client_secret`.
+* `mobileAuthorizationUri` - Authorization URI for the mobile app OAuth2 server. This authorization URI is used if the second argument of authorizeURL call is true.
 
 ```javascript
 // Set the configuration settings

--- a/lib/client/auth-code.js
+++ b/lib/client/auth-code.js
@@ -14,10 +14,13 @@ module.exports = function(config) {
   // * `params.state` - A String that represents an optional opaque value used by the client to
   // maintain state between the request and the callback.
   //
-  function authorizeURL(params) {
+  function authorizeURL(params, is_mobile) {
     params.response_type = 'code';
     params.client_id = config.clientID;
 
+    if (is_mobile) {
+      return config.mobileAuthorizationUri + '?' + qs.stringify(params);
+    }
     return config.site + config.authorizationPath + '?' + qs.stringify(params);
   }
 

--- a/test/auth-code.js
+++ b/test/auth-code.js
@@ -1,18 +1,29 @@
-var credentials = { clientID: 'client-id', clientSecret: 'client-secret', site: 'https://example.org' },
+var credentials = { clientID: 'client-id', clientSecret: 'client-secret', site: 'https://example.org', mobileAuthorizationUri: 'example://app/authorize' },
     oauth2 = require('./../lib/simple-oauth2.js')(credentials),
     qs = require('querystring'),
     nock = require('nock');
 
-var request, result, error;
+var request, result, error, result_mobile;
 
 describe('oauth2.authCode',function() {
 
   describe('#authorizeURL', function(){
 
+    var params = { 'redirect_uri': 'http://localhost:3000/callback', 'scope': 'user', 'state': '02afe928b' };
+
     beforeEach(function(done) {
-      var params = { 'redirect_uri': 'http://localhost:3000/callback', 'scope': 'user', 'state': '02afe928b' };
       result = oauth2.authCode.authorizeURL(params);
       done();
+    })
+
+    beforeEach(function(done) {
+      result_mobile = oauth2.authCode.authorizeURL(params, true);
+      done();
+    })
+
+    it('returns the authorization URI for mobile apps', function() {
+      var expected = 'example://app/authorize?redirect_uri=' + encodeURIComponent('http://localhost:3000/callback') + '&scope=user&state=02afe928b&response_type=code&client_id=client-id';
+      result_mobile.should.eql(expected);
     })
 
     it('returns the authorization URI', function() {


### PR DESCRIPTION
Add mobileAuthorizationUri to the configuration. authorizeURL uses this
path instead of authorizationPath when its second argument is true.