### PR TITLE
Refresh Token without Authorization header #32

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ Simple OAuth2 accepts an object with the following valid params.
 * `tokenPath` - Access token path for the OAuth2 server. Defaults to `/oauth/token`.
 * `revocationPath` - Revocation token path for the OAuth2 server. Defaults to `/oauth/revoke`.
 * `useBasicAuthorizationHeader` - Whether or not the `Authorization: Basic ...` header is set on the request.
+* `useBasicAuthorizationHeaderWhenRefreshingToken` - Whether or not the `Authorization: Basic ...` header is set on the refresh token request.
 Defaults to `true`.
 * `clientSecretParameterName` - Parameter name for the client secret. Defaults to `client_secret`.
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -6,5 +6,6 @@ module.exports = {
   'clientSecret': null,
   'site': null,
   'useBasicAuthorizationHeader': true,
+  'useBasicAuthorizationHeaderWhenRefreshingToken': true,
   'clientSecretParameterName': 'client_secret'
 }

--- a/lib/core.js
+++ b/lib/core.js
@@ -43,7 +43,7 @@ module.exports = function(config) {
       options.headers = { 'Authorization': 'Bearer ' + params.access_token }
       delete params.access_token;
     }
-    else if (config.useBasicAuthorizationHeader && config.clientID && !params.client_id)
+    else if (config.useBasicAuthorizationHeader && config.clientID && !params.client_id && (config.useBasicAuthorizationHeaderWhenRefreshingToken || params.grant_type !== 'refresh_token' ))
       options.headers = { 'Authorization': 'Basic ' + new Buffer(config.clientID + ':' + config.clientSecret).toString('base64') }
     else
       options.headers = {}


### PR DESCRIPTION
Create a new configuration option to specify if the Authorization header should be sent on refresh token requests.