### PR TITLE
Allows passing full url path for authorization URL

### DIFF
--- a/lib/client/auth-code.js
+++ b/lib/client/auth-code.js
@@ -15,10 +15,12 @@ module.exports = function (config) {
    *         								to main the state between the request and the callback
    */
   function authorizeURL(params) {
+    var isAbsoluteUrl;
     params.response_type = 'code';
     params.client_id = config.clientID;
 
-    return config.site + config.authorizationPath + '?' + qs.stringify(params);
+    isAbsoluteUrl = config.authorizationPath.lastIndexOf('http://', 0) === 0 || config.authorizationPath.lastIndexOf('https://', 0) === 0;
+    return (isAbsoluteUrl ? config.authorizationPath : config.site + config.authorizationPath) + '?' + qs.stringify(params);
   }
 
   /**


### PR DESCRIPTION
Added same from core api function to allow absolute urls, should not break anything