### PR TITLE
Allows an absolute URL for the authorizationPath

### DIFF
--- a/lib/client/auth-code.js
+++ b/lib/client/auth-code.js
@@ -4,6 +4,7 @@
 module.exports = function (config) {
   var core = require('./../core')(config);
   var qs = require('querystring');
+  var Url = require('url');
 
   /**
    * Redirect the user to the autorization page
@@ -18,7 +19,13 @@ module.exports = function (config) {
     params.response_type = 'code';
     params.client_id = config.clientID;
 
-    return config.site + config.authorizationPath + '?' + qs.stringify(params);
+    var isAbsolute = String(Url.parse(config.authorizationPath).protocol)
+      .match(/https?/);
+
+    return (isAbsolute ?
+      config.authorizationPath :
+      config.site + config.authorizationPath
+    ) + '?' + qs.stringify(params);
   }
 
   /**

--- a/lib/core.js
+++ b/lib/core.js
@@ -4,6 +4,7 @@ var request = Promise.promisify(require('request'));
 
 module.exports = function (config) {
   var errors = require('./error')();
+  var Url = require('url');
 
   // High level method to call API
   function api(method, path, params, callback) {
@@ -17,7 +18,8 @@ module.exports = function (config) {
 
     utils.log('OAuth2 Node Request');
 
-    isAbsoluteUrl = path.lastIndexOf('http://', 0) === 0 || path.lastIndexOf('https://', 0) === 0;
+    isAbsoluteUrl = String(Url.parse(path).protocol)
+      .match(/https?/);
     url = isAbsoluteUrl ? path : config.site + path;
 
     return call(method, url, params).spread(data).nodeify(callback);

--- a/test/auth-code.js
+++ b/test/auth-code.js
@@ -12,12 +12,24 @@ var request,
 
 describe('oauth2.authCode', function () {
   describe('#authorizeURL', function () {
-    beforeEach(function () {
-      result = oauth2.authCode.authorizeURL(authorizeConfig);
-    });
 
     it('returns the authorization URI', function () {
+      result = oauth2.authCode.authorizeURL(authorizeConfig);
+
       var expected = 'https://example.org/oauth/authorize?redirect_uri=' + encodeURIComponent('http://localhost:3000/callback') + '&scope=user&state=02afe928b&response_type=code&client_id=client-id';
+      result.should.eql(expected);
+    });
+
+    it('should allow absolute URI for authorizationPath', function () {
+      var oauth2 = require('./../index')({
+        clientID: 'client-id',
+        clientSecret: 'client-secret',
+        site: 'https://example.org',
+        authorizationPath: 'https://othersite.com/oauth/authorize'
+      });
+      result = oauth2.authCode.authorizeURL(authorizeConfig);
+
+      var expected = 'https://othersite.com/oauth/authorize?redirect_uri=' + encodeURIComponent('http://localhost:3000/callback') + '&scope=user&state=02afe928b&response_type=code&client_id=client-id';
       result.should.eql(expected);
     });
   });


### PR DESCRIPTION
Partially adresses #55, #29 and #40.

Switched from `url.resolve` to a different method, since invocation of `url.resolve('http://foo.bar/baz/', 'qux')` would result in `http://foo.bar/qux`.