### PR TITLE
give chance to pass through unencoded params

### DIFF
--- a/lib/client/auth-code.js
+++ b/lib/client/auth-code.js
@@ -13,12 +13,17 @@ module.exports = function (config) {
    *         params.scope - A String that represents the application privileges
    *         params.state - A String that represents an option opaque value used by the client
    *         								to main the state between the request and the callback
+   * @param  {Object} unencodedParams - Params you do NOT want to be url encoded
    */
-  function authorizeURL(params) {
+  function authorizeURL(params, unencodedParams) {
     params.response_type = 'code';
     params.client_id = config.clientID;
 
-    return config.site + config.authorizationPath + '?' + qs.stringify(params);
+    var url = config.site + config.authorizationPath + '?' + qs.stringify(params);
+    if (unencodedParams) {
+      url += '&' + qs.unescape(qs.stringify(unencodedParams));
+    }
+    return url;
   }
 
   /**


### PR DESCRIPTION
Hi there,
I came across this issue: the oauth server I'm trying to authenticate against wants scopes separated by '+' and it expects it to be '+' and not the url encoded version.

It seemed like a good idea to add an extra param where it's possible to pass an object of params that you don't want to be url-encoded.

What do you think? is there a better way to address this issue (on client side)?

Cheers