### PR TITLE
Added support for optional sending of auth params in body.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Next
+* Added optional sending support to the body auth params.
 * Updated license information.
 * Updated main dependencies version.
 * Fixed leaked token when a refresh token was used.

--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ Simple OAuth2 accepts an object with the following valid params.
 * `useBasicAuthorizationHeader` - Whether or not the `Authorization: Basic ...` header is set on the request.
 Defaults to `true`.
 * `clientSecretParameterName` - Parameter name for the client secret. Defaults to `client_secret`.
+* `useBodyAuth` - Wheather or not the clientID/clientSecret params are sent in the request body. Defaults to `true`.
 
 ```javascript
 // Set the configuration settings

--- a/lib/config.js
+++ b/lib/config.js
@@ -6,5 +6,6 @@ module.exports = {
   clientSecret: null,
   site: null,
   useBasicAuthorizationHeader: true,
-  clientSecretParameterName: 'client_secret'
+  clientSecretParameterName: 'client_secret',
+  useBodyAuth: true
 };

--- a/lib/core.js
+++ b/lib/core.js
@@ -68,7 +68,7 @@ module.exports = function (config) {
 
     // Enable the system to send authorization params in the body
     // For example github does not require to be in the header
-    if (method !== 'GET' && options.form) {
+    if (config.useBodyAuth && options.form) {
       options.form.client_id = config.clientID;
       options.form[config.clientSecretParameterName] = config.clientSecret;
     }


### PR DESCRIPTION
An `config.useAuthBody` configuration option was added to allow to explicitly ignore the auth params in body (non GET) requests.

This solves the same problem as #36 using a different approach.
