### PR TITLE
Added clientID and clientSecret to Authorization Code flow

### DIFF
--- a/lib/client/auth-code.js
+++ b/lib/client/auth-code.js
@@ -37,6 +37,8 @@ module.exports = function (config) {
    *                             An error object is passed as first argument and the result as last.
    */
   function getToken(params, callback) {
+    params.client_id = config.clientID;
+    params.client_secret = config.clientSecret;
     params.grant_type = 'authorization_code';
     return core
       .api('POST', config.tokenPath, params)


### PR DESCRIPTION
Authorization Code flow was not sending client id and client secret params so getToken was always returning 401 status code. With this fix auth-code flow works as expected.