### PR TITLE
Use expires_at property passed into accessToken.create.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Changed public api to, to make it consistent. Changed shortcut names to full names.
 * Changed public api to allow different sites for /authorize and /tokens
 * Added strict schema validation to module options.
+* Does not override expires_at property if passed into accessToken.create.
 
 ## v0.8.0 (1 August 2016)
 * Upgraded code to strict mode.

--- a/lib/client/access-token.js
+++ b/lib/client/access-token.js
@@ -3,6 +3,8 @@
 const url = require('url');
 const addSeconds = require('date-fns/add_seconds');
 const isAfter = require('date-fns/is_after');
+const isDate = require('date-fns/is_date');
+const parse = require('date-fns/parse');
 const coreModule = require('./../core');
 
 /**
@@ -15,7 +17,13 @@ module.exports = (config) => {
 
   function AccessToken(token) {
     this.token = token;
-    this.token.expires_at = addSeconds(new Date(), token.expires_in);
+    if ('expires_at' in this.token) {
+      if (!isDate(this.token.expires_at)) {
+        this.token.expires_at = parse(this.token.expires_at);
+      }
+    } else {
+      this.token.expires_at = addSeconds(new Date(), token.expires_in);
+    }
   }
 
   /**

--- a/test/access_token.js
+++ b/test/access_token.js
@@ -6,6 +6,8 @@ const path = require('path');
 const expect = require('chai').expect;
 const startOfYesterday = require('date-fns/start_of_yesterday');
 const oauth2Module = require('./../index.js');
+const isValid = require('date-fns/is_valid');
+const isEqual = require('date-fns/is_equal');
 
 const oauth2 = oauth2Module
   .create(require('./fixtures/oauth-options'));
@@ -58,6 +60,29 @@ describe('oauth2.accessToken', function () {
     it('creates an access token wrapper object', function () {
       expect(token).to.have.property('token');
       expect(tokenPromise).to.have.property('token');
+    });
+  });
+
+  describe('#create with expires_at', function () {
+    it('uses the set expires_at property', function () {
+      token.token.expires_at = startOfYesterday();
+      const expiredToken = oauth2.accessToken.create(token.token);
+      expect(isValid(expiredToken.token.expires_at)).to.be.equal(true);
+      expect(isEqual(expiredToken.token.expires_at, token.token.expires_at))
+        .to.be.equal(true);
+    });
+
+    it('parses a set expires_at property', function () {
+      const yesterday = startOfYesterday();
+      token.token.expires_at = yesterday.toString();
+      const expiredToken = oauth2.accessToken.create(token.token);
+      expect(isValid(expiredToken.token.expires_at)).to.be.equal(true);
+      expect(isEqual(expiredToken.token.expires_at, token.token.expires_at))
+        .to.be.equal(true);
+    });
+
+    it('create its own date by default', function () {
+      expect(isValid(token.token.expires_at)).to.be.equal(true);
     });
   });
 
@@ -142,6 +167,10 @@ describe('oauth2.accessToken', function () {
 
     it('makes the HTTP request', function () {
       expect(request.isDone()).to.be.equal(true);
+    });
+
+    it('returns a new oauth2.accessToken as result of callback api', function () {
+      expect(result.token).to.have.property('access_token');
     });
 
     it('returns a new oauth2.accessToken as a result of the token refresh', function () {


### PR DESCRIPTION
I addressed the issues in PR https://github.com/lelylan/simple-oauth2/pull/80 which solves Issue https://github.com/lelylan/simple-oauth2/issues/59. This allows users to save tokens to a persistent store and still use the `accessToken` seamlessly without overwriting the `expires_at` property.
 
On another note, some of the tests used assertions like `foo.should.be.true` which is not actually a valid assertinon, it should look like: `foo.should.be.true()`. It does not seem that the previous assertions were being run. Docs: http://shouldjs.github.io/#assertion-true

Hope this helps merging this functionality sooner! Let me know if there are any other changes / tests necessary.