### PR TITLE
Develop - updated example to fix bug

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -34,6 +34,8 @@ app.get('/callback', (req, res) => {
   const code = req.query.code;
   const options = {
     code,
+    //The trailing comma on the line above indicates something was missed
+    redirect_uri: 'http://localhost:3000/callback'
   };
 
   oauth2.authorizationCode.getToken(options, (error, result) => {


### PR DESCRIPTION
The callback in the example was missing the redirect_url.  It worked successfully for me after adding it.  There was a trailing comma in the code, indicating this was missed and a bug in the example.
