### PR TITLE
Add option for `expirationBuffer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Simple OAuth2 accepts an object with the following valid params.
   - `bodyFormat` - Format of data sent in the request body. Valid values are `form` or `json`. Defaults to **form**.
   - `useBodyAuth` - Whether or not the client.id/client.secret params are sent in the request body. Defaults to **true**.
   - `useBasicAuthorizationHeader` - Whether or not the Basic Authorization header should be sent at the token request.
+  - `expiredBuffer` - Number of seconds before an access token's real expiration time to report it as expired. Defaults to **0**.
 
 ```javascript
 // Set the configuration settings

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Simple OAuth2 accepts an object with the following valid params.
   - `bodyFormat` - Format of data sent in the request body. Valid values are `form` or `json`. Defaults to **form**.
   - `useBodyAuth` - Whether or not the client.id/client.secret params are sent in the request body. Defaults to **true**.
   - `useBasicAuthorizationHeader` - Whether or not the Basic Authorization header should be sent at the token request.
-  - `expiredBuffer` - Number of seconds before an access token's real expiration time to report it as expired. Defaults to **0**.
+  - `expirationBuffer` - Number of seconds before an access token's real expiration time to report it as expired. Defaults to **0**.
 
 ```javascript
 // Set the configuration settings

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const optionsSchema = joi
       bodyFormat: joi.any().valid('form', 'json').default('form'),
       useBasicAuthorizationHeader: joi.boolean().default(true),
       useBodyAuth: joi.boolean().default(true),
-      expirationBuffer: joi.number().default(0),
+      expirationBuffer: joi.number().min(0).default(0),
     }).default(),
   });
 

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ const optionsSchema = joi
       bodyFormat: joi.any().valid('form', 'json').default('form'),
       useBasicAuthorizationHeader: joi.boolean().default(true),
       useBodyAuth: joi.boolean().default(true),
+      expiredBuffer: joi.number().default(0),
     }).default(),
   });
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const optionsSchema = joi
       bodyFormat: joi.any().valid('form', 'json').default('form'),
       useBasicAuthorizationHeader: joi.boolean().default(true),
       useBodyAuth: joi.boolean().default(true),
-      expiredBuffer: joi.number().default(0),
+      expirationBuffer: joi.number().default(0),
     }).default(),
   });
 

--- a/lib/client/access-token.js
+++ b/lib/client/access-token.js
@@ -2,6 +2,7 @@
 
 const url = require('url');
 const addSeconds = require('date-fns/add_seconds');
+const subSeconds = require('date-fns/sub_seconds');
 const isAfter = require('date-fns/is_after');
 const isDate = require('date-fns/is_date');
 const parse = require('date-fns/parse');
@@ -41,7 +42,8 @@ module.exports = (config) => {
   * Check if the access token is expired or not
   */
   AccessToken.prototype.expired = function expired() {
-    return isAfter(new Date(), this.token.expires_at);
+    const safeExpiresAt = subSeconds(this.token.expires_at, config.options.expiredBuffer);
+    return isAfter(new Date(), safeExpiresAt);
   };
 
   /**

--- a/lib/client/access-token.js
+++ b/lib/client/access-token.js
@@ -42,7 +42,7 @@ module.exports = (config) => {
   * Check if the access token is expired or not
   */
   AccessToken.prototype.expired = function expired() {
-    const safeExpiresAt = subSeconds(this.token.expires_at, config.options.expiredBuffer);
+    const safeExpiresAt = subSeconds(this.token.expires_at, config.options.expirationBuffer);
     return isAfter(new Date(), safeExpiresAt);
   };
 


### PR DESCRIPTION
When checking if an access token has expired, there is a common race
condition where using a near-expiring token may actually be expired by
the time the API server checks it. This is due to things like round-trip
latency, clock skew, processing time, etc.

One solution is to allow clients to configure a buffer so that a token
will be reported as "expired" before it actually is. This allows some
leeway to account for various latencies.

Fixes #131