### PR TITLE
use defaults to allow setting response_type

### DIFF
--- a/lib/client/auth-code.js
+++ b/lib/client/auth-code.js
@@ -3,6 +3,7 @@
 const url = require('url');
 const qs = require('querystring');
 const coreModule = require('./../core');
+const defaults = require('lodash.defaults');
 
 /**
  * Authorization Code flow implementation
@@ -22,7 +23,7 @@ module.exports = (config) => {
    * @return {String} the absolute authorization url
    */
   function authorizeURL(params) {
-    const options = Object.assign({}, params, {
+    const options = defaults(params, {
       response_type: 'code',
       [config.client.idParamName]: config.client.id,
     });

--- a/lib/client/auth-code.js
+++ b/lib/client/auth-code.js
@@ -3,7 +3,6 @@
 const url = require('url');
 const qs = require('querystring');
 const coreModule = require('./../core');
-const defaults = require('lodash.defaults');
 
 /**
  * Authorization Code flow implementation
@@ -23,10 +22,10 @@ module.exports = (config) => {
    * @return {String} the absolute authorization url
    */
   function authorizeURL(params) {
-    const options = defaults(params, {
+    const options = Object.assign({}, {
       response_type: 'code',
       [config.client.idParamName]: config.client.id,
-    });
+    }, params);
 
     return `${authorizeUrl}?${qs.stringify(options)}`;
   }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "date-fns": "^1.3.0",
     "debug": "^2.2.0",
     "joi": "^10.4.1",
+    "lodash.defaults": "^4.2.0",
     "request": "^2.81.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "date-fns": "^1.3.0",
     "debug": "^2.2.0",
     "joi": "^10.4.1",
-    "lodash.defaults": "^4.2.0",
     "request": "^2.81.0"
   },
   "devDependencies": {

--- a/test/auth-code.js
+++ b/test/auth-code.js
@@ -26,7 +26,7 @@ describe('oauth2.authCode', function () {
     it('returns the authorization URI', function () {
       result = oauth2.authorizationCode.authorizeURL(authorizeConfig);
 
-      const expected = `https://example.org/oauth/authorize?redirect_uri=${encodeURIComponent('http://localhost:3000/callback')}&scope=user&state=02afe928b&response_type=code&client_id=client-id`;
+      const expected = `https://example.org/oauth/authorize?response_type=code&client_id=client-id&redirect_uri=${encodeURIComponent('http://localhost:3000/callback')}&scope=user&state=02afe928b`;
       expect(result).to.be.equal(expected);
     });
 
@@ -44,7 +44,7 @@ describe('oauth2.authCode', function () {
 
       result = oauth2Temp.authorizationCode.authorizeURL(authorizeConfig);
 
-      const expected = `https://example.org/oauth/authorize?redirect_uri=${encodeURIComponent('http://localhost:3000/callback')}&scope=user&state=02afe928b&response_type=code&incredible-param-name=client-id`;
+      const expected = `https://example.org/oauth/authorize?response_type=code&incredible-param-name=client-id&redirect_uri=${encodeURIComponent('http://localhost:3000/callback')}&scope=user&state=02afe928b`;
 
       expect(result).to.be.equal(expected);
     });
@@ -63,7 +63,7 @@ describe('oauth2.authCode', function () {
 
       result = oauth2Temp.authorizationCode.authorizeURL(authorizeConfig);
 
-      const expected = `https://othersite.com/oauth/authorize?redirect_uri=${encodeURIComponent('http://localhost:3000/callback')}&scope=user&state=02afe928b&response_type=code&client_id=client-id`;
+      const expected = `https://othersite.com/oauth/authorize?response_type=code&client_id=client-id&redirect_uri=${encodeURIComponent('http://localhost:3000/callback')}&scope=user&state=02afe928b`;
 
       expect(result).to.be.equal(expected);
     });


### PR DESCRIPTION
In order to be compatible with multiple openID `response_type` values we need to be able to set this value manually, the current implementation assumes the `response_type` will always be `code` and overwrites arguments passed to the constructor.

see http://openid.net/specs/openid-connect-core-1_0.html#code-id_tokenExample