### PR TITLE
Check for, and Bluebird-promisify config.requestOverride option

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ const optionsSchema = joi
       useBasicAuthorizationHeader: joi.boolean().default(true),
       useBodyAuth: joi.boolean().default(true),
     }).default(),
+    requestOverride: joi.func().arity(1),
   });
 
 module.exports = {

--- a/lib/core.js
+++ b/lib/core.js
@@ -93,7 +93,7 @@ module.exports = (config) => {
 
     debug('Making the HTTP request', options);
 
-    return request(options);
+    return (typeof config.requestOverride === 'function') ? Promise.resolve(config.requestOverride(options)) : request(options);
   }
 
   // High level method to call API

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-oauth2",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Node.js client for OAuth2",
   "author": "Andrea Reginato <andrea.reginato@gmail.com>",
   "contributors": [


### PR DESCRIPTION
Allow an alternative request module, by passing in a config attribute `requestOverride`.

This allows us to supply a function that returns a promise, in this case a service-discovery aware http request module