### PR TITLE
Added ability to specify HTTP method for client credentials workflow

### DIFF
--- a/lib/client/access-token.js
+++ b/lib/client/access-token.js
@@ -48,16 +48,11 @@ module.exports = (config) => {
   * Refresh the access token
   * @param  {Object} An optional argument for additional API request params.
   * @param  {Function} callback
-  * @param  {String} [method=POST] A string that represents the HTTP request method
   */
-  AccessToken.prototype.refresh = function refresh(params, callback, method) {
+  AccessToken.prototype.refresh = function refresh(params, callback) {
     if (typeof params === 'function') {
       callback = params;
       params = undefined;
-    }
-
-    if (method == null) {
-      method = 'POST';
     }
 
     const options = Object.assign({}, params || {}, {
@@ -66,7 +61,7 @@ module.exports = (config) => {
     });
 
     return core
-      .api(method, tokenUrl, options)
+      .api('POST', tokenUrl, options)
       .then(response => createAccessToken(response))
       .nodeify(callback);
   };
@@ -76,21 +71,16 @@ module.exports = (config) => {
   * @param  {String}   tokenType A string containing the type of token to revoke.
   *                              Should be either "access_token" or "refresh_token"
   * @param  {Function} callback
-  * @param  {String} [method=POST] A string that represents the HTTP request method
   */
-  AccessToken.prototype.revoke = function revoke(tokenType, callback, method) {
+  AccessToken.prototype.revoke = function revoke(tokenType, callback) {
     const token = tokenType === 'access_token' ? this.token.access_token : this.token.refresh_token;
     const options = {
       token,
       token_type_hint: tokenType,
     };
 
-    if (method == null) {
-      method = 'POST';
-    }
-
     return core
-      .api(method, revokeUrl, options)
+      .api('POST', revokeUrl, options)
       .nodeify(callback);
   };
 

--- a/lib/client/access-token.js
+++ b/lib/client/access-token.js
@@ -48,11 +48,16 @@ module.exports = (config) => {
   * Refresh the access token
   * @param  {Object} An optional argument for additional API request params.
   * @param  {Function} callback
+  * @param  {String} [method=POST] A string that represents the HTTP request method
   */
-  AccessToken.prototype.refresh = function refresh(params, callback) {
+  AccessToken.prototype.refresh = function refresh(params, callback, method) {
     if (typeof params === 'function') {
       callback = params;
       params = undefined;
+    }
+
+    if (method == null) {
+      method = 'POST';
     }
 
     const options = Object.assign({}, params || {}, {
@@ -61,7 +66,7 @@ module.exports = (config) => {
     });
 
     return core
-      .api('POST', tokenUrl, options)
+      .api(method, tokenUrl, options)
       .then(response => createAccessToken(response))
       .nodeify(callback);
   };
@@ -71,16 +76,21 @@ module.exports = (config) => {
   * @param  {String}   tokenType A string containing the type of token to revoke.
   *                              Should be either "access_token" or "refresh_token"
   * @param  {Function} callback
+  * @param  {String} [method=POST] A string that represents the HTTP request method
   */
-  AccessToken.prototype.revoke = function revoke(tokenType, callback) {
+  AccessToken.prototype.revoke = function revoke(tokenType, callback, method) {
     const token = tokenType === 'access_token' ? this.token.access_token : this.token.refresh_token;
     const options = {
       token,
       token_type_hint: tokenType,
     };
 
+    if (method == null) {
+      method = 'POST';
+    }
+
     return core
-      .api('POST', revokeUrl, options)
+      .api(method, revokeUrl, options)
       .nodeify(callback);
   };
 

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -15,14 +15,19 @@ module.exports = (config) => {
    * @param  {String} params.scope A string that represents the application privileges
    * @param  {Function} callback
    * @return {Promise}
+   * @param  {String} [method=POST] A string that represents the HTTP request method
    */
-  function getToken(params, callback) {
+  function getToken(params, callback, method) {
     const options = Object.assign({}, params || {}, {
       grant_type: 'client_credentials',
     });
 
+    if (method == null) {
+      method = 'POST';
+    }
+
     return core
-      .api('POST', tokenUrl, options)
+      .api(method, tokenUrl, options)
       .nodeify(callback);
   }
 


### PR DESCRIPTION
Change:
I was playing with an OAuth2 API that implemented the client credentials flows, but it only accepted a GET request instead of a POST request. So this PR makes a change to the client.js that allows you to specify the HTTP request method, and if none is defined then it defaults to 'POST'.

Note:
I haven't made the analogous changes to the password.js and auth-code.js files because in those flows I've never come across GET requests, so I chose to keep the library smaller. However, an argument can be made to make all the `getToken` functions consistent and accept the optional `method` param, let me know if I should do that.