### PR TITLE
Fixes #151: Update debug version to fix ReDoS attack vector

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "date-fns": "^1.3.0",
-    "debug": "^3.0.1",
+    "debug": "^3.1.0",
     "joi": "^12.0.0",
     "request": "^2.81.0"
   },


### PR DESCRIPTION
Just followed the guidelines of your dependencies checker. https://david-dm.org/lelylan/simple-oauth2 and https://nodesecurity.io/advisories/debug_regular-expression-denial-of-service.

I ran the tests suite and they all passed.