### PR TITLE
Fix client_id/client_secret string requirements

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,12 +6,15 @@ const passwordModule = require('./lib/client/password');
 const accessTokenModule = require('./lib/client/access-token');
 const clientCredentialsModule = require('./lib/client/client');
 
+// https://tools.ietf.org/html/draft-ietf-oauth-v2-31#appendix-A.1
+const vsCharRegEx = /^[\x20-\x7E]*$/;
+
 const optionsSchema = Joi
   .object()
   .keys({
     client: Joi.object().keys({
-      id: Joi.string().allow(''),
-      secret: Joi.string().allow(''),
+      id: Joi.string().regex(vsCharRegEx).allow(''),
+      secret: Joi.string().regex(vsCharRegEx).allow(''),
       secretParamName: Joi.string().default('client_secret'),
       idParamName: Joi.string().default('client_id'),
     }).required(),

--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ const optionsSchema = Joi
   .object()
   .keys({
     client: Joi.object().keys({
-      id: Joi.string().required(),
-      secret: Joi.string().required(),
+      id: Joi.string().allow(''),
+      secret: Joi.string().allow(''),
       secretParamName: Joi.string().default('client_secret'),
       idParamName: Joi.string().default('client_id'),
     }).required(),


### PR DESCRIPTION
The OAuth2 spec allows these to be zero or more visual ASCII characters.
https://tools.ietf.org/html/draft-ietf-oauth-v2-31#appendix-A.1

> VSCHAR = %x20-7E
>
> A.1.  "client_id" Syntax
>    The "client_id" element is defined in Section 2.3.1:
>      client-id     = *VSCHAR
>
> A.2.  "client_secret" Syntax
>    The "client_secret" element is defined in Section 2.3.1:
>      client-secret = *VSCHAR

This PR includes two changes. The first is to explicitly allow empty strings. ([Joi requires this to be explicit](https://github.com/hapijs/joi/blob/v13.1.2/API.md#string---inherits-from-any)). The second commit restricts the character set to the range given in the spec, which is all visual non-control ASCII characters.


Fixes https://github.com/lelylan/simple-oauth2/issues/170