### PR TITLE
Support multiple scopes provided as an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ const oauth2 = require('simple-oauth2').create(credentials);
 // Authorization oauth2 URI
 const authorizationUri = oauth2.authorizationCode.authorizeURL({
   redirect_uri: 'http://localhost:3000/callback',
-  scope: '<scope>',
+  scope: '<scope>', // also can be an array of multiple scopes, ex. ['<scope1>, '<scope2>', '...']
   state: '<state>'
 });
 

--- a/lib/client/auth-code.js
+++ b/lib/client/auth-code.js
@@ -22,6 +22,10 @@ module.exports = (config) => {
    * @return {String} the absolute authorization url
    */
   function authorizeURL(params) {
+    if (params && params.scope && params.scope instanceof Array) {
+      params.scope = params.scope.join(',');
+    }
+
     const options = Object.assign({}, {
       response_type: 'code',
       [config.client.idParamName]: config.client.id,

--- a/test/auth-code.js
+++ b/test/auth-code.js
@@ -32,6 +32,18 @@ describe('authorization code grant type', () => {
       });
     });
 
+    describe('with multiple scopes in configuration provided as an array', () => {
+      const authConfigMultScopesAry = Object.assign({}, authorizeConfig, { scope: ['user', 'account'] });
+
+      it('returns the authorization URI with scopes joined by commas', () => {
+        const oauth2 = oauth2Module.create(baseConfig);
+        const authorizationURL = oauth2.authorizationCode.authorizeURL(authConfigMultScopesAry);
+        const expectedAuthorizationURL = `https://authorization-server.org/oauth/authorize?response_type=code&client_id=the%20client%20id&redirect_uri=${encodeURIComponent('http://localhost:3000/callback')}&scope=user%2Caccount&state=02afe928b`;
+
+        expect(authorizationURL).to.be.equal(expectedAuthorizationURL);
+      });
+    });
+
     describe('with custom configuration', () => {
       it('uses a custom idParamName', () => {
         const oauth2Temp = oauth2Module.create({


### PR DESCRIPTION
It is usually more developer-friendly to be able to provide OAuth scopes as an array and let the library handle serializing them as needed when initializing the OAuth flow. This PR checks if scopes are provided and if they're type is an array, and joins them as needed by OAuth servers to allow easier handling of requiring different scopes based on the application needs.