### PR TITLE
Use strict JSON parsing mode

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -20,7 +20,7 @@ module.exports = (config) => {
   async function request(url, params) {
     let payload = params;
     const options = {
-      json: true,
+      json: 'strict',
       headers: {},
     };
 


### PR DESCRIPTION
The Oauth standard mandates responses are JSON. As such, it might be preferable to throw an error than to return an invalid response body.

I was hitting an invalid Oauth endpoint and receiving a buffer back since the response content type wasn't JSON. It was pretty confusing, so it seems like it might be better to just throw an error than to return a non-JSON response body.