### PR TITLE
Follow redirects

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -22,6 +22,7 @@ module.exports = (config) => {
     const options = {
       json: true,
       headers: {},
+      redirects: 20,
     };
 
     if (config.options.authorizationMethod === 'header') {


### PR DESCRIPTION
Instruct wreck to follow up to 20 redirects.

I was trying to get a token from a server that redirected from the bare domain to www, which wasn't working because wreck wasn't instructed to follow redirects. Unless there's a security consideration, this seems like it makes the library more ergonomic. I picked 20 redirects because that seems to be standard for browsers.