### PR TITLE
Encode multiple scopes using space instead of comma

### DIFF
--- a/lib/client/auth-code.js
+++ b/lib/client/auth-code.js
@@ -28,7 +28,7 @@ module.exports = (config) => {
     };
 
     if (Array.isArray(params.scope)) {
-      params.scope = params.scope.join(',');
+      params.scope = params.scope.join(' ');
     }
 
     const options = Object.assign({}, baseParams, params);

--- a/test/auth-code.js
+++ b/test/auth-code.js
@@ -47,7 +47,7 @@ describe('authorization code grant type', () => {
         it('returns the authorization URI with scopes joined by commas', () => {
           const oauth2 = oauth2Module.create(baseConfig);
           const authorizationURL = oauth2.authorizationCode.authorizeURL(authConfigMultScopesAry);
-          const expectedAuthorizationURL = `https://authorization-server.org/oauth/authorize?response_type=code&client_id=the%20client%20id&redirect_uri=${encodeURIComponent('http://localhost:3000/callback')}&scope=user%2Caccount&state=02afe928b`;
+          const expectedAuthorizationURL = `https://authorization-server.org/oauth/authorize?response_type=code&client_id=the%20client%20id&redirect_uri=${encodeURIComponent('http://localhost:3000/callback')}&scope=user%20account&state=02afe928b`;
 
           expect(authorizationURL).to.be.equal(expectedAuthorizationURL);
         });


### PR DESCRIPTION
According to the spec, scopes should be joined using a single space: https://tools.ietf.org/html/rfc6749#appendix-A.4
https://tools.ietf.org/html/rfc6749#section-3.3

This fixes #186  is an alternative to PR #187 