### PR TITLE
Update `auth.tokenHost` uri validation method

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const optionsSchema = Joi
       idParamName: Joi.string().default('client_id'),
     }).required(),
     auth: Joi.object().keys({
-      tokenHost: Joi.string().required().uri(['http', 'https']),
+      tokenHost: Joi.string().required().uri({ scheme: ['http', 'https'] }),
       tokenPath: Joi.string().default('/oauth/token'),
       revokePath: Joi.string().default('/oauth/revoke'),
       authorizeHost: Joi.string().default(Joi.ref('tokenHost')),


### PR DESCRIPTION
Update the `auth.tokenHost` to now use the prefered `scheme` options
object 👍 