### PR TITLE
fix: allow authorize URLs that already have query params

### DIFF
--- a/lib/client/auth-code.js
+++ b/lib/client/auth-code.js
@@ -32,8 +32,9 @@ module.exports = (config) => {
     }
 
     const options = Object.assign({}, baseParams, params);
-
-    return `${authorizeUrl}?${qs.stringify(options)}`;
+    const joint = authorizeUrl.indexOf('?') > -1 ? '&' : '?';
+    
+    return `${authorizeUrl}${joint}${qs.stringify(options)}`;
   }
 
   /**

--- a/lib/client/auth-code.js
+++ b/lib/client/auth-code.js
@@ -33,7 +33,7 @@ module.exports = (config) => {
 
     const options = Object.assign({}, baseParams, params);
     const joint = authorizeUrl.indexOf('?') > -1 ? '&' : '?';
-    
+
     return `${authorizeUrl}${joint}${qs.stringify(options)}`;
   }
 


### PR DESCRIPTION
This PRs allows to have authorize URLs that already have query params. This is useful in dynamic scenarios where the authorize URL is defined by a user.