### PR TITLE
WIP: Changing order of Object.assign inside getToken

### DIFF
--- a/lib/client/auth-code.js
+++ b/lib/client/auth-code.js
@@ -43,9 +43,9 @@ module.exports = (config) => {
    * @return {Promise}
    */
   async function getToken(params) {
-    const options = Object.assign({}, params, {
+    const options = Object.assign({}, {
       grant_type: 'authorization_code',
-    });
+    }, params);
 
     return core.request(config.auth.tokenPath, options);
   }


### PR DESCRIPTION
With regards to this issue https://github.com/lelylan/simple-oauth2/issues/210.

The fix is simple enough, just change the order of the arguments passed to Object.assign() so that users arguments take priority. 

However i am facing issues with tests, 3 tests are failing

Here is the log


 3 failing

  1) authorization code grant type
       when requesting an access token
         with body credentials
           with format form
             "before all" hook:
     Error: Client request error: Nock: No match for request {
  "method": "POST",
  "url": "https://authorization-server.org/oauth/token",
  "headers": {
    "accept": "application/json",
    "content-type": "application/x-www-form-urlencoded",
    "content-length": 142
  },
  "body": "grant_type=authorization_code&code=code&redirect_uri=http%3A%2F%2Fcallback.com&client_id=the%20client%20id&client_secret=the%20client%20secret"
}
      at end (node_modules/nock/lib/request_overrider.js:279:17)
      at node_modules/nock/lib/request_overrider.js:162:9
      at OverriddenClientRequest.RequestOverrider.req.write (node_modules/nock/lib/request_overrider.js:141:9)
      at OverriddenClientRequest.RequestOverrider.req.end (node_modules/nock/lib/request_overrider.js:158:11)
      at internals.Client._request (node_modules/wreck/lib/index.js:326:9)
      at internals.Client.request (node_modules/wreck/lib/index.js:108:22)
      at internals.Client._shortcut (node_modules/wreck/lib/index.js:568:28)
      at internals.Client.post (node_modules/wreck/lib/index.js:544:17)
      at Object.request (lib/core.js:5:297)
      at Object.getToken (lib/client/auth-code.js:17:193)
      at Context.before (test/auth-code.js:200:51)

  2) Simple oauth2 Error
       with status code 500
         performs the http request:

      AssertionError [ERR_ASSERTION]: Mocks not yet satisfied:
POST https://authorization-server.org:443/oauth/token
      + expected - actual

      -false
      +true

      at Scope.done (node_modules/nock/lib/scope.js:156:10)
      at Context.it (test/errors.js:94:13)

  3) Simple oauth2 Error
       with status code 500
         rejects with a boom error:

      AssertionError: expected { Object (message, statusCode, ...) } to deeply equal { Object (error, message, ...) }
      + expected - actual

       {
      -  "error": "Bad Gateway"
      -  "message": "Client request error: Nock: No match for request {\n  \"method\": \"POST\",\n  \"url\": \"https://authorization-server.org/oauth/token\",\n  \"headers\": {\n    \"accept\": \"application/json\",\n    \"authorization\": \"Basic dGhlK2NsaWVudCtpZDp0aGUrY2xpZW50K3NlY3JldA==\",\n    \"content-type\": \"application/x-www-form-urlencoded\",\n    \"content-length\": 78\n  },\n  \"body\": \"grant_type=authorization_code&code=code&redirect_uri=http%3A%2F%2Fcallback.com\"\n}"
      -  "statusCode": 502
      +  "error": "Internal Server Error"
      +  "message": "An internal server error occurred"
      +  "statusCode": 500
       }

      at Proxy.assertEqual (node_modules/chai/lib/chai/core/assertions.js:1020:19)
      at Proxy.methodWrapper (node_modules/chai/lib/chai/utils/addMethod.js:57:25)
      at Context.it (test/errors.js:106:47)



----------------------
I was able to see that in case of the updated code few extra headers were being passed to the API.