### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -227,11 +227,11 @@
       "dev": true
     },
     "boom": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
-      "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
+      "integrity": "sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==",
       "requires": {
-        "hoek": "5.x.x"
+        "hoek": "6.x.x"
       }
     },
     "boundary": {
@@ -475,9 +475,9 @@
       "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw=="
     },
     "debug": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.0.1.tgz",
-      "integrity": "sha512-K23FHJ/Mt404FSlp6gSZCevIbTMLX0j3fmHhUEhQ3Wq0FMODW3+cUSoLdy1Gx4polAf4t/lphhmHH35BB8cLYw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+      "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
       "requires": {
         "ms": "^2.1.1"
       }
@@ -1103,9 +1103,9 @@
       "dev": true
     },
     "hoek": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
-      "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
+      "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -1313,9 +1313,9 @@
       "dev": true
     },
     "isemail": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.3.tgz",
-      "integrity": "sha512-5xbsG5wYADIcB+mfLsd+nst1V/D+I7EU7LEZPo2GOIMu4JzfcRs5yQoypP4avA7QtUqgxYLKBYNv4IdzBmbhdw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
       "requires": {
         "punycode": "2.x.x"
       }
@@ -1356,11 +1356,11 @@
       }
     },
     "joi": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-13.6.0.tgz",
-      "integrity": "sha512-E4QB0yRgEa6ZZKcSHJuBC+QeAwy+akCG0Bsa9edLqljyhlr+GuGDSmXYW1q7sj/FuAPy+ECUI3evVtK52tVfwg==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.0.tgz",
+      "integrity": "sha512-0HKd1z8MWogez4GaU0LkY1FgW30vR2Kwy414GISfCU41OYgUC2GWpNe5amsvBZtDqPtt7DohykfOOMIw1Z5hvQ==",
       "requires": {
-        "hoek": "5.x.x",
+        "hoek": "6.x.x",
         "isemail": "3.x.x",
         "topo": "3.x.x"
       }
@@ -3364,7 +3364,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -3384,11 +3384,11 @@
       "dev": true
     },
     "topo": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
-      "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
       "requires": {
-        "hoek": "5.x.x"
+        "hoek": "6.x.x"
       }
     },
     "traverse": {
@@ -3570,12 +3570,12 @@
       "dev": true
     },
     "wreck": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/wreck/-/wreck-14.1.0.tgz",
-      "integrity": "sha512-y/iwFhwdGoM8Hk1t1I4LbuLhM3curVD8STd5NcFI0c/4b4cQAMLcnCRxXX9sLQAggDC8dXYSaQNsT64hga6lvA==",
+      "version": "14.1.3",
+      "resolved": "https://registry.npmjs.org/wreck/-/wreck-14.1.3.tgz",
+      "integrity": "sha512-hb/BUtjX3ObbwO3slCOLCenQ4EP8e+n8j6FmTne3VhEFp5XV1faSJojiyxVSvw34vgdeTG5baLTl4NmjwokLlw==",
       "requires": {
         "boom": "7.x.x",
-        "hoek": "5.x.x"
+        "hoek": "6.x.x"
       }
     },
     "write": {

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
   ],
   "dependencies": {
     "date-fns": "^1.3.0",
-    "debug": "~4.0.1",
-    "joi": "~13.6.0",
-    "wreck": "~14.1.0"
+    "debug": "^4.1.0",
+    "joi": "^14.1.0",
+    "wreck": "^14.1.3"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
This avoids depending on a deprecated `hoek`.

- Debug 4.0.0 [dropped support for Node.js 4 & 5, shouldn't affect us](https://github.com/visionmedia/debug/releases/tag/4.0.0)
- Joi 14.0.0 [doesn't seem to have any breaking changes affecting us](https://github.com/hapijs/joi/issues/1615)