### PR TITLE
Documentation Fix - Passing multiple scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ const oauth2 = require('simple-oauth2').create(credentials);
 // Authorization oauth2 URI
 const authorizationUri = oauth2.authorizationCode.authorizeURL({
   redirect_uri: 'http://localhost:3000/callback',
-  scope: '<scope>', // also can be an array of multiple scopes, ex. ['<scope1>, '<scope2>', '...']
+  scope: '<scope>', // for multiple scopes, use a space-delimited string, ex. 'scope-1 scope-2'
   state: '<state>'
 });
 
@@ -134,7 +134,7 @@ res.redirect(authorizationUri);
 const tokenConfig = {
   code: '<code>',
   redirect_uri: 'http://localhost:3000/callback',
-  scope: '<scope>', // also can be an array of multiple scopes, ex. ['<scope1>, '<scope2>', '...']
+  scope: '<scope>', // for multiple scopes, use a space-delimited string, ex. 'scope-1 scope-2'
 };
 
 // Save the access token
@@ -161,7 +161,7 @@ const oauth2 = require('simple-oauth2').create(credentials);
 const tokenConfig = {
   username: 'username',
   password: 'password',
-  scope: '<scope>', // also can be an array of multiple scopes, ex. ['<scope1>, '<scope2>', '...']
+  scope: '<scope>', // for multiple scopes, use a space-delimited string, ex. 'scope-1 scope-2'
 };
 
 // Save the access token
@@ -180,7 +180,7 @@ This flow is suitable when client is requesting access to the protected resource
 ```javascript
 const oauth2 = require('simple-oauth2').create(credentials);
 const tokenConfig = {
-  scope: '<scope>', // also can be an array of multiple scopes, ex. ['<scope1>, '<scope2>', '...']
+  scope: '<scope>', // for multiple scopes, use a space-delimited string, ex. 'scope-1 scope-2'
 };
 
 // Get the access token object for the client


### PR DESCRIPTION
The documentation indicates that multiple scopes may be passed as an array of strings.  However, this results in an incorrect payload due to the way [`stringify`](https://github.com/lelylan/simple-oauth2/blob/master/lib/core.js#L50) handles the url encoding of arrays.  If an array is passed for `scope` the resulting url-encoded body contains multiple `scope` parameters. e.g.

```scope=scope-1&scope=scope-2```

As per [Sec 3.3 of the OAuth spec](https://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-3.3), scope should be passed as a space-delimited string.  Therefore, when multiple scopes are desired, the `scope` parameter passed to `simple-oauth2` methods should contain a space delimited string of the desired scopes. ex.

```scope: 'scope-1 scope-2'```

This will result in a url-encoded body of the following form:

```scope=scope-1%2Cscope-2```

Note:  The [auth-code flow correctly encodes `scope`](https://github.com/lelylan/simple-oauth2/blob/master/lib/client/auth-code.js#L30-L32) parameters on to the auth URL.  This issue applies only to password and client credentials flows.  An alternate fix would be to add similar code to the auth-code and password clients.