### PR TITLE
Add integration tests to token/host host and path resolution process

### DIFF
--- a/test/auth-code.js
+++ b/test/auth-code.js
@@ -91,6 +91,24 @@ describe('authorization code grant type', () => {
         expect(authorizationURL).to.be.equal(expectedAuthorizationURL);
       });
 
+      it('uses a custom authorizeHost with trailing slashes', () => {
+        const oauth2 = oauth2Module.create({
+          client: {
+            id: 'client-id',
+            secret: 'client-secret',
+          },
+          auth: {
+            tokenHost: 'https://authorization-server.org',
+            authorizeHost: 'https://other-authorization-server.com/root/',
+          },
+        });
+
+        const authorizationURL = oauth2.authorizationCode.authorizeURL(authorizeConfig);
+        const expectedAuthorizationURL = `https://other-authorization-server.com/oauth/authorize?response_type=code&client_id=client-id&redirect_uri=${encodeURIComponent('http://localhost:3000/callback')}&scope=user&state=02afe928b`;
+
+        expect(authorizationURL).to.be.equal(expectedAuthorizationURL);
+      });
+
       it('uses a custom authorizePath', () => {
         const oauth2 = oauth2Module.create({
           client: {
@@ -105,6 +123,25 @@ describe('authorization code grant type', () => {
 
         const authorizationURL = oauth2.authorizationCode.authorizeURL(authorizeConfig);
         const expectedAuthorizationURL = `https://authorization-server.org/authorize-now?response_type=code&client_id=client-id&redirect_uri=${encodeURIComponent('http://localhost:3000/callback')}&scope=user&state=02afe928b`;
+
+        expect(authorizationURL).to.be.equal(expectedAuthorizationURL);
+      });
+
+      it('uses a custom authorizeHost and authorizePath', () => {
+        const oauth2 = oauth2Module.create({
+          client: {
+            id: 'client-id',
+            secret: 'client-secret',
+          },
+          auth: {
+            tokenHost: 'https://authorization-server.org',
+            authorizeHost: 'https://other-authorization-server.com',
+            authorizePath: '/authorize-now',
+          },
+        });
+
+        const authorizationURL = oauth2.authorizationCode.authorizeURL(authorizeConfig);
+        const expectedAuthorizationURL = `https://other-authorization-server.com/authorize-now?response_type=code&client_id=client-id&redirect_uri=${encodeURIComponent('http://localhost:3000/callback')}&scope=user&state=02afe928b`;
 
         expect(authorizationURL).to.be.equal(expectedAuthorizationURL);
       });
@@ -251,6 +288,51 @@ describe('authorization code grant type', () => {
       });
 
       it('resolves the access token', () => {
+        expect(result).to.be.deep.equal(expectedAccessToken);
+      });
+    });
+
+    describe('with custom token host and path', () => {
+      before(() => {
+        const scopeOptions = {
+          reqheaders: {
+            Accept: 'application/json',
+          },
+        };
+
+        const expectedRequestParams = {
+          code: 'code',
+          redirect_uri: 'http://callback.com',
+          grant_type: 'authorization_code',
+        };
+
+        scope = nock('https://authorization-server.org', scopeOptions)
+          .post('/root/oauth/token', expectedRequestParams)
+          .reply(200, expectedAccessToken);
+      });
+
+      before(async () => {
+        const config = Object.assign({}, baseConfig, {
+          auth: {
+            tokenHost: 'https://authorization-server.org:443/root/',
+            tokenPath: '/oauth/token',
+          },
+        });
+
+        const tokenParams = {
+          code: 'code',
+          redirect_uri: 'http://callback.com',
+        };
+
+        const oauth2 = oauth2Module.create(config);
+        result = await oauth2.authorizationCode.getToken(tokenParams);
+      });
+
+      it('performs the http request', () => {
+        scope.done();
+      });
+
+      it('returns an access token as result of the token request', () => {
         expect(result).to.be.deep.equal(expectedAccessToken);
       });
     });

--- a/test/client.js
+++ b/test/client.js
@@ -136,6 +136,41 @@ describe('client credentials grant type', () => {
       });
     });
 
+    describe('with custom token host and path', () => {
+      before(() => {
+        const scopeOptions = {
+          reqheaders: {
+            Accept: 'application/json',
+            Authorization: 'Basic dGhlK2NsaWVudCtpZDp0aGUrY2xpZW50K3NlY3JldA==',
+          },
+        };
+
+        scope = nock('https://authorization-server.org:443', scopeOptions)
+          .post('/root/oauth/token')
+          .reply(200, expectedAccessToken);
+      });
+
+      before(async () => {
+        const config = Object.assign({}, baseConfig, {
+          auth: {
+            tokenHost: 'https://authorization-server.org:443/root/',
+            tokenPath: '/oauth/token',
+          },
+        });
+
+        const oauth2 = oauth2Module.create(config);
+        result = await oauth2.clientCredentials.getToken(tokenParams);
+      });
+
+      it('performs the http request', () => {
+        scope.done();
+      });
+
+      it('returns an access token as result of the token request', () => {
+        expect(result).to.be.deep.equal(expectedAccessToken);
+      });
+    });
+
     describe('with additional http configuration', () => {
       before(() => {
         const scopeOptions = {

--- a/test/password.js
+++ b/test/password.js
@@ -137,6 +137,44 @@ describe('owner password gran type', () => {
       });
     });
 
+    describe('with custom token host and path', () => {
+      let scope;
+      let result;
+
+      before(() => {
+        const scopeOptions = {
+          reqheaders: {
+            Accept: 'application/json',
+            Authorization: 'Basic dGhlK2NsaWVudCtpZDp0aGUrY2xpZW50K3NlY3JldA==',
+          },
+        };
+
+        scope = nock('https://authorization-server.org:443', scopeOptions)
+          .post('/root/oauth/token')
+          .reply(200, expectedAccessToken);
+      });
+
+      before(async () => {
+        const config = Object.assign({}, baseConfig, {
+          auth: {
+            tokenHost: 'https://authorization-server.org:443/root/',
+            tokenPath: '/oauth/token',
+          },
+        });
+
+        const oauth2 = oauth2Module.create(config);
+        result = await oauth2.ownerPassword.getToken(tokenOptions);
+      });
+
+      it('performs the http request', () => {
+        scope.done();
+      });
+
+      it('returns an access token as result of the token request', () => {
+        expect(result).to.be.deep.equal(expectedAccessToken);
+      });
+    });
+
     describe('with additional http configuration', () => {
       let scope;
       let result;


### PR DESCRIPTION
In preparation to migrate towards @hapi/wreck 15, we need to make sure that wreck [breaking changes](https://github.com/hapijs/wreck/issues/244) do not leak into this library configuration. Adding some integration tests to prevent that.