### PR TITLE
UTF-8 encode user-pass using `encodeURI` method instead of `encodeURIComponent`

### DIFF
--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -2,18 +2,6 @@
 
 const HEADER_ENCODING_FORMAT = 'base64';
 
-/**
- * Encode a single {value} using the application/x-www-form-urlencoded media type
- * while also applying some additional rules specified by the spec
- *
- * @see https://tools.ietf.org/html/rfc6749#appendix-B
- *
- * @param {String} value
- */
-function useFormURLEncode(value) {
-  return encodeURIComponent(value).replace(/%20/g, '+');
-}
-
 module.exports = {
   /**
    * Get the authorization header used to request a valid token
@@ -22,7 +10,7 @@ module.exports = {
    * @return {String}              Authorization header string token
    */
   getAuthorizationHeaderToken(clientID, clientSecret) {
-    const encodedCredentials = `${useFormURLEncode(clientID)}:${useFormURLEncode(clientSecret)}`;
+    const encodedCredentials = encodeURI(`${clientID}:${clientSecret}`);
 
     return Buffer.from(encodedCredentials).toString(HEADER_ENCODING_FORMAT);
   },

--- a/test/_authorization-server-mock.js
+++ b/test/_authorization-server-mock.js
@@ -142,7 +142,7 @@ function getHeaderCredentialsScopeOptions(options = {}) {
   return Hoek.applyToDefaults({
     reqheaders: {
       Accept: 'application/json',
-      Authorization: 'Basic dGhlK2NsaWVudCtpZDp0aGUrY2xpZW50K3NlY3JldA==',
+      Authorization: 'Basic dGhlJTIwY2xpZW50JTIwaWQ6dGhlJTIwY2xpZW50JTIwc2VjcmV0',
     },
   }, options);
 }

--- a/test/access_token.js
+++ b/test/access_token.js
@@ -8,17 +8,12 @@ const { isValid, isDate, differenceInSeconds } = require('date-fns');
 
 const oauth2Module = require('./../index.js');
 const { createModuleConfig } = require('./_module-config');
-const { createAuthorizationServer } = require('./_authorization-server-mock');
+const { createAuthorizationServer, getHeaderCredentialsScopeOptions } = require('./_authorization-server-mock');
 
 const chance = new Chance();
 chance.mixin({ accessToken: accessTokenMixin });
 
-const scopeOptions = {
-  reqheaders: {
-    Accept: 'application/json',
-    Authorization: 'Basic dGhlK2NsaWVudCtpZDp0aGUrY2xpZW50K3NlY3JldA==',
-  },
-};
+const scopeOptions = getHeaderCredentialsScopeOptions();
 
 test('@create => creates a new access token instance', (t) => {
   const config = createModuleConfig();


### PR DESCRIPTION
- Fixes #271 
- UTF-8 encoding for `user-pass` in Basic Authentication header as mentioned in [RFC 7617](https://tools.ietf.org/html/rfc7617)
- Fixed tests
  - Replaced duplicated `scopeOptions` with `getHeaderCredentialsScopeOptions` method
  - Regenerated `base64` encoded value for `Authorization` header