### PR TITLE
Missing encoding sequences as per RFC3986

### DIFF
--- a/lib/client/credentials-encoding.js
+++ b/lib/client/credentials-encoding.js
@@ -11,13 +11,22 @@ const credentialsEncodingModeEnum = {
  * Encode a single {value} using the application/x-www-form-urlencoded media type
  * while also applying some additional rules specified by the spec
  *
+ * Following characters are not-escaped by encodeURIComponent but {@link https://tools.ietf.org/html/rfc3986 RFC 3986}
+ * lists them as 'reserved' and hence needs to be percent encoded, though they have no formalized URI delimiting cases
+ *
+ * >   ! ' ( ) *
+ *
+ * Percent encoding needs to be uppercase hexadecimal as per {@link https://tools.ietf.org/html/rfc3986#section-2.1 RFC 3986 - Percent Encoding}
+ *
  * @see https://tools.ietf.org/html/rfc6749#appendix-B
  * @see https://tools.ietf.org/html/rfc6749#section-2.3.1
  *
  * @param {String} value
  */
 function useFormURLEncode(value) {
-  return encodeURIComponent(value).replace(/%20/g, '+');
+  return encodeURIComponent(value)
+    .replace(/%20/g, '+')
+    .replace(/[!'()*]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
 }
 
 /**

--- a/test/client-credentials-grant-type.js
+++ b/test/client-credentials-grant-type.js
@@ -180,6 +180,43 @@ test.serial('@getToken => resolves to an access token with custom module configu
   t.true(accessToken instanceof AccessToken);
 });
 
+test.serial('@getToken => resolves to an access token with custom module configuration (header credentials with unescaped characters + strict encoding)', async (t) => {
+  const expectedRequestParams = {
+    grant_type: 'client_credentials',
+    random_param: 'random value',
+  };
+
+  const scopeOptions = getHeaderCredentialsScopeOptions({
+    reqheaders: {
+      Authorization: 'Basic SSUyN20rdGhlX2NsaWVudC1pZCUyMSslMjYrJTI4c3ltYm9scyUyQSUyOTpJJTI3bSt0aGVfY2xpZW50LXNlY3JldCUyMSslMjYrJTI4c3ltYm9scyUyQSUyOQ==',
+    },
+  });
+
+  const server = createAuthorizationServer('https://authorization-server.org:443');
+  const scope = server.tokenSuccess(scopeOptions, expectedRequestParams);
+
+  const config = createModuleConfig({
+    client: {
+      id: 'I\'m the_client-id! & (symbols*)',
+      secret: 'I\'m the_client-secret! & (symbols*)',
+    },
+    options: {
+      authorizationMethod: 'header',
+      credentialsEncodingMode: 'strict',
+    },
+  });
+
+  const tokenParams = {
+    random_param: 'random value',
+  };
+
+  const oauth2 = new ClientCredentials(config);
+  const accessToken = await oauth2.getToken(tokenParams);
+
+  scope.done();
+  t.true(accessToken instanceof AccessToken);
+});
+
 test.serial('@getToken => resolves to an access token with custom module configuration (access token host and path)', async (t) => {
   const expectedRequestParams = {
     grant_type: 'client_credentials',

--- a/test/resource-owner-password-grant-type.js
+++ b/test/resource-owner-password-grant-type.js
@@ -190,6 +190,45 @@ test.serial('@getToken => resolves to an access token with custom module configu
   t.true(accessToken instanceof AccessToken);
 });
 
+test.serial('@getToken => resolves to an access token with custom module configuration (header credentials with unescaped characters + strict encoding)', async (t) => {
+  const tokenRequestParams = {
+    grant_type: 'password',
+    username: 'alice',
+    password: 'secret',
+  };
+
+  const scopeOptions = getHeaderCredentialsScopeOptions({
+    reqheaders: {
+      Authorization: 'Basic SSUyN20rdGhlX2NsaWVudC1pZCUyMSslMjYrJTI4c3ltYm9scyUyQSUyOTpJJTI3bSt0aGVfY2xpZW50LXNlY3JldCUyMSslMjYrJTI4c3ltYm9scyUyQSUyOQ==',
+    },
+  });
+
+  const server = createAuthorizationServer('https://authorization-server.org:443');
+  const scope = server.tokenSuccess(scopeOptions, tokenRequestParams);
+
+  const config = createModuleConfig({
+    client: {
+      id: 'I\'m the_client-id! & (symbols*)',
+      secret: 'I\'m the_client-secret! & (symbols*)',
+    },
+    options: {
+      authorizationMethod: 'header',
+      credentialsEncodingMode: 'strict',
+    },
+  });
+
+  const tokenParams = {
+    username: 'alice',
+    password: 'secret',
+  };
+
+  const oauth2 = new ResourceOwnerPassword(config);
+  const accessToken = await oauth2.getToken(tokenParams);
+
+  scope.done();
+  t.true(accessToken instanceof AccessToken);
+});
+
 test.serial('@getToken => resolves to an access token with custom module configuration (access token host and path)', async (t) => {
   const tokenRequestParams = {
     grant_type: 'password',


### PR DESCRIPTION
As discussed earlier in this PR https://github.com/lelylan/simple-oauth2/pull/272#issuecomment-545720893, adopted the missing sequences as outlined in the [encodeURIComponent()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#Description) MDN documentation.

Also, have updated the test cases, to use `!'()*` characters