### PR TITLE
Allow expires_at to be a UNIX timestamp

### DIFF
--- a/lib/access-token.js
+++ b/lib/access-token.js
@@ -17,7 +17,11 @@ function parseToken(token) {
 
   if ('expires_at' in token) {
     if (!isDate(token.expires_at)) {
-      tokenProperties.expires_at = parseISO(token.expires_at);
+      if (typeof token.expires_at === 'number') {
+        tokenProperties.expires_at = new Date(token.expires_at * 1000);
+      } else {
+        tokenProperties.expires_at = parseISO(token.expires_at);
+      }
     }
   } else if ('expires_in' in token) {
     tokenProperties.expires_at = getExpirationDate(token.expires_in);

--- a/test/access_token.js
+++ b/test/access_token.js
@@ -50,7 +50,25 @@ test('@create => do not reassigns the expires at property when is already a date
   t.true(isValid(accessToken.token.expires_at));
 });
 
-test('@create => parses the expires at property when is not a date', (t) => {
+test('@create => parses the expires at property when is UNIX timestamp in seconds', (t) => {
+  const config = createModuleConfig();
+  const oauth2 = oauth2Module.create(config);
+
+  const accessTokenResponse = chance.accessToken({
+    expired: true,
+    parseDate: false,
+    expireMode: 'expires_at',
+  });
+  // Sometimes expires_at is also given as a UNIX timestamp in seconds:
+  accessTokenResponse.expires_at = Math.round(new Date(accessTokenResponse.expires_at).getTime() / 1000);
+
+  const accessToken = oauth2.accessToken.create(accessTokenResponse);
+
+  t.true(isDate(accessToken.token.expires_at));
+  t.true(isValid(accessToken.token.expires_at));
+});
+
+test('@create => parses the expires at property when is ISO time', (t) => {
   const config = createModuleConfig();
   const oauth2 = oauth2Module.create(config);
 


### PR DESCRIPTION
This library currently only handles expires_at properties well when they
are provided in ISOString representation.

Unlike the expires_in field, the expires_at is not part of the OAuth2
spec, so implementations may vary.

Some APIs like the Strava API use a UNIX timestamp (seconds since epoch)
in the expires_at field:
http://developers.strava.com/docs/authentication/#response-parameters-1

Token refresh will yield "Invalid Date" in the expires_at field when
only accepting an ISOString.

This patch checks if expires_at is a number and if so assumes it is a
UNIX timestamp (seconds since epoch).