### PR TITLE
Adds state generation and validation for Auth Code Grant

### DIFF
--- a/API.md
+++ b/API.md
@@ -31,6 +31,7 @@ Simple OAuth2 accepts an object with the following params.
   * `credentialsEncodingMode` Setup how credentials are encoded when `options.authorizationMode` is **header**. Use **loose** if your provider doesn't conform the [OAuth2 specification](https://tools.ietf.org/html/rfc6749#section-2.3.1). Defaults to **strict**
   * `bodyFormat` - Request's body data format. Valid options are `form` or `json`. Defaults to **form**
   * `authorizationMethod` - Method used to send the *client.id*/*client.secret* authorization params at the token request. Valid options are `header` or `body`. If set to **body**, the **bodyFormat** option will be used to format the credentials. Defaults to **header**
+  * `generateState` - For Authorization Code Grant requests, generate a `state` parameter that can later be validated before the `getToken` request in accordance to the [OAuth2 specification](https://tools.ietf.org/html/rfc6749#section-10.12). Defaults to **false**
 
 ## Module
 ### .authorizationCode
@@ -41,7 +42,7 @@ Creates the authorization URL from the *client configuration* and the *authorize
 
 * `redirectURI` String representing the registered application URI where the user is redirected after authentication
 * `scope` String or array of strings representing the application privileges
-* `state` String representing an opaque value used by the client to main the state between the request and the callback
+* `state` String representing an opaque value used by the client to main the state between the request and the callback. If using the `generateState` option, passing in a `state` value is ignored.
 
 Additional options will be automatically serialized as query params in the resulting URL.
 
@@ -52,6 +53,8 @@ Get a new access token using the current grant type.
   * `code` Authorization code received by the callback URL
   * `redirectURI` Application callback URL
   * `[scope]` Optional string or array including a subset of the original client scopes to request
+  * `redirect_response_url` Optional Used for `state` validation, URL returned from the Authorization server containing the provided `state` parameter.
+  * `authorize_url` Optional URL generated from the `authorizeURL` function. When combined with the `redirect_response_url` will validate that the `state` parameter matches between API calls.
 
 Additional options will be automatically serialized as params for the token request.
 

--- a/index.js
+++ b/index.js
@@ -40,8 +40,8 @@ const optionsSchema = Joi.object().keys({
     .string()
     .valid(...Object.values(authorizationMethodEnum))
     .default(authorizationMethodEnum.HEADER),
-      generateState: Joi.boolean().default(false),
-    }).default();
+  generateState: Joi.boolean().default(false),
+}).default();
 
 const moduleOptionsSchema = Joi.object().keys({
   client: clientSchema,

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ const optionsSchema = Joi
       credentialsEncodingMode: Joi.string().valid('strict', 'loose').default('strict'),
       bodyFormat: Joi.string().valid('form', 'json').default('form'),
       authorizationMethod: Joi.any().valid('header', 'body').default('header'),
+      generateState: Joi.boolean().default(false),
     }).default(),
   });
 

--- a/lib/grants/authorization-code.js
+++ b/lib/grants/authorization-code.js
@@ -4,6 +4,28 @@ const { URL } = require('url');
 const querystring = require('querystring');
 const GrantParams = require('../grant-params');
 
+function generateState() {
+  const length = 64;
+  let state = '';
+  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  for (let i = 0; i < length; i += 1) {
+    state += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return state;
+}
+
+function validateState(redirectResponseUrl, authorizeURL) {
+  if (redirectResponseUrl && authorizeURL) {
+    const redirectResponseParams = new URL(redirectResponseUrl);
+    const authorizeParams = new URL(authorizeURL);
+
+    if (redirectResponseParams.searchParams.get('state') !== authorizeParams.searchParams.get('state')) {
+      throw new Error('State in refererURL does not match the original state from authorizeURL. '
+        + 'This may be an indicator of a CSRF attack.');
+    }
+  }
+}
+
 module.exports = class AuthorizationCode {
   constructor(config, client) {
     this.config = config;
@@ -26,8 +48,10 @@ module.exports = class AuthorizationCode {
       [this.config.client.idParamName]: this.config.client.id,
     };
 
+    const configuredParams = this.config.options.generateState ? { ...params, state: generateState() } : params;
+
     const url = new URL(this.config.auth.authorizePath, this.config.auth.authorizeHost);
-    const parameters = new GrantParams(this.config.options, baseParams, params);
+    const parameters = new GrantParams(this.config.options, baseParams, configuredParams);
 
     return `${url}?${querystring.stringify(parameters.toObject())}`;
   }
@@ -36,13 +60,18 @@ module.exports = class AuthorizationCode {
    * Requests and returns an access token from the authorization server
    *
    * @param {String} params.code Authorization code (from previous step)
-   * @param {String} params.redirecURI String representing the registered application URI where the user is redirected after authentication
+   * @param {String} params.redirect_uri String representing the registered application URI where the user is redirected after authentication
+   * @param {String} params.redirect_response_url Optional Used for `state` validation, URL returned from the Authorization server containing the provided `state` parameter.
+   * @param {String} params.authorize_url Optional URL generated from the `authorizeURL` function. When combined with the `redirect_response_url` will validate that the `state` parameter matches between API calls.
    * @param {String|Array<String>} [params.scope] String or array of strings representing the application privileges
    * @param {Object} [httpOptions] Optional http options passed through the underlying http library
    * @return {Promise}
    */
   async getToken(params, httpOptions) {
-    const parameters = GrantParams.forGrant('authorization_code', this.config.options, params);
+    const { redirect_response_url: redirectResponseUrl, authorize_url: authorizeUrl, ...requestParams } = { ...params };
+    validateState(redirectResponseUrl, authorizeUrl);
+
+    const parameters = GrantParams.forGrant('authorization_code', this.config.options, requestParams);
 
     return this.client.request(this.config.auth.tokenPath, parameters.toObject(), httpOptions);
   }


### PR DESCRIPTION
I'm implementing a few different authentication libraries for different languages. I've loved the simplicity of this library so far, but I'd like to include state generation and validation as a part of this library in order to defend against CSRF attacks: https://tools.ietf.org/html/rfc6749#section-10.12

As to not introduce breaking changes, I've added an optional `generateState` config option, that allows the library to generate this state value, as well as two optional parameters `redirect_response_url` and `authorize_url` that allows the library to validate that the state has not been modified. This keeps the library stateless, while still providing this generation and validation functionality.

The only other thing I could think of would be to throw an error if `generateState` is provided, but `redirect_response_url` and `authorize_url` are not provided, but curious to your thoughts. Let me know if there is a better way to configure besides the `config.options.generateState`, if there are clearer naming conventions, documentation I can add, or additional test cases to cover.

I realized after the fact that I was working against node 12. If you plan on accepting #292 before this, then this should be good to go. But, if you would like to accept this first, I've got some code ready on a branch https://github.com/AndrewBell/simple-oauth2/tree/fork-develop-node-8 But, I'm having trouble running the tests, as ajv is failing with an unreported error.