### PR TITLE
Fixed date-fns requires

### DIFF
--- a/lib/access-token.js
+++ b/lib/access-token.js
@@ -2,10 +2,7 @@
 
 const Hoek = require('@hapi/hoek');
 const debug = require('debug')('simple-oauth2:access-token');
-const isDate = require('date-fns/isDate');
-const parseISO = require('date-fns/parseISO');
-const addSeconds = require('date-fns/addSeconds');
-const isBefore = require('date-fns/isBefore');
+const { isDate, parseISO, addSeconds, isBefore } = require('date-fns');
 
 const GrantParams = require('./grant-params');
 


### PR DESCRIPTION
It looks like `date-fns` changed the way they export their functions, which causes this error when trying to do an authorization code flow:

```
Access token error TypeError: addSeconds is not a function
    at getExpirationDate (access-token.js:13)
    at parseToken (access-token.js:28)
    at new AccessToken (access-token.js:51)
    at Object.create (access-token.js:41)
 ```

I branched from 3.3.0 as I can see that you've refactored the whole access-token.js file since that release, but from what I've seen you're still calling `require()` in a way that is broken.