### PR TITLE
Add support for OAUTH2 Token servers requiring URL string parameters

### DIFF
--- a/lib/authorization-code-grant-type.js
+++ b/lib/authorization-code-grant-type.js
@@ -47,7 +47,14 @@ module.exports = class AuthorizationCode {
    */
   async getToken(params, httpOptions) {
     const parameters = GrantTypeParams.forGrantType('authorization_code', this.#config.options, params);
-    const response = await this.#client.request(this.#config.auth.tokenPath, parameters.toObject(), httpOptions);
+    let response = '';
+    if(this.#config.auth.tokenUseURL === true) {
+      const usePath = this.#config.auth.tokenPath+'?'+`${querystring.stringify(parameters.toObject())}`;
+      response = await this.#client.request(usePath, '', httpOptions);
+    } else {
+      response = await this.#client.request(this.#config.auth.tokenPath, parameters.toObject(), httpOptions);
+    }
+    
 
     return this.createToken(response);
   }

--- a/lib/config.js
+++ b/lib/config.js
@@ -19,6 +19,7 @@ const authSchema = Joi.object().keys({
   revokePath: Joi.string().default('/oauth/revoke'),
   authorizeHost: Joi.string().uri({ scheme: ['http', 'https'] }).default(Joi.ref('tokenHost')),
   authorizePath: Joi.string().default('/oauth/authorize'),
+  tokenUseURL: Joi.boolean().default(false),
 }).required();
 
 const optionsSchema = Joi.object().keys({


### PR DESCRIPTION
Add support for OAUTH2 token servers that require the parameters be passed in the URL query string instead of the body. Added config option #config.auth.tokenUseURL, defaulting to false.

Example: https://github.com/slivertv/thetatv-app-docs (passing the values in the body returns a 500 internal server error)