### PR TITLE
Deprecate simple-oauth2 v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@
 
 | Version                                                                          | Node support        |
 |----------------------------------------------------------------------------------|---------------------|
-| [3.x](https://github.com/lelylan/simple-oauth2/tree/3.x)                         | Node 8.x or higher  |
 | [4.x (Current)](https://github.com/lelylan/simple-oauth2/tree/master)            | Node 12.x or higher |
 
 Older node versions are unsupported.


### PR DESCRIPTION
Dropping support for simple-oauth2@v3 as Node 8 has reached EOL.