### PR TITLE
Docs: Mention that custom params can be passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ async function run() {
   const authorizationUri = client.authorizeURL({
     redirect_uri: 'http://localhost:3000/callback',
     scope: '<scope>',
-    state: '<state>'
+    state: '<state>',
+    
+    customParam: 'foo', // non-standard oauth params may be passed as well
   });
 
   // Redirect example using Express (see http://expressjs.com/api.html#res.redirect)


### PR DESCRIPTION
This should also be considered for the JSDoc of this method, but I'm not sure the best way to document that.

Additionally—while I know that typescript typings are not the responsibility of this library, those that implemented the typings were not aware of this option: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/simple-oauth2/index.d.ts#L208

And thus my TS code has an error (despite working in JS):
<img width="1041" alt="Screenshot 2023-03-10 at 23 20 19" src="https://user-images.githubusercontent.com/1933021/224459940-4f5363b1-8675-4c07-a730-cd9ca5ada8a1.png">

If these official docs can support this option, I can update the TS typings.