### PR TITLE
upgrading @hapi/hoek to ^11.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,14 @@
       "dev": true,
       "requires": {
         "@hapi/hoek": "10.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        }
       }
     },
     "@hapi/bourne": {
@@ -42,9 +50,9 @@
       "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w=="
     },
     "@hapi/hoek": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
-      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw=="
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
+      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
     },
     "@hapi/topo": {
       "version": "5.1.0",
@@ -78,6 +86,11 @@
           "requires": {
             "@hapi/hoek": "10.x.x"
           }
+        },
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "credentials"
   ],
   "dependencies": {
-    "@hapi/hoek": "^10.0.1",
+    "@hapi/hoek": "^11.0.4",
     "@hapi/wreck": "^18.0.0",
     "debug": "^4.3.4",
     "joi": "^17.6.4"


### PR DESCRIPTION
#438

With node 20.x.x simple-oauth2 throws below error if being used with http-proxy-agent and https-proxy-agent with below error:

"**Client request error: Cannot read private member #context from an object whose class did not declare it**".

Hapi has given fix in their latest version, upgrading it to fix the issue , please find the hapi fix in below PR

https://github.com/hapijs/hoek/pull/392

@jonathansamines could you please take a look and approve this PR

